### PR TITLE
Remove iconv_set_encoding for PHP 5.6+

### DIFF
--- a/src/AmazonPhpClientLibrary/MarketplaceWebService/Client.php
+++ b/src/AmazonPhpClientLibrary/MarketplaceWebService/Client.php
@@ -89,10 +89,6 @@ class MarketplaceWebService_Client implements MarketplaceWebService_Interface
    */
   public function __construct(
   $awsAccessKeyId, $awsSecretAccessKey, $config, $applicationName, $applicationVersion, $attributes = null) {
-	iconv_set_encoding('output_encoding', 'UTF-8');
-    iconv_set_encoding('input_encoding', 'UTF-8');
-    iconv_set_encoding('internal_encoding', 'UTF-8');
-
     $this->awsAccessKeyId = $awsAccessKeyId;
     $this->awsSecretAccessKey = $awsSecretAccessKey;
     if (!is_null($config)) 

--- a/src/AmazonPhpClientLibrary/MarketplaceWebServiceProducts/Client.php
+++ b/src/AmazonPhpClientLibrary/MarketplaceWebServiceProducts/Client.php
@@ -896,9 +896,11 @@ class MarketplaceWebServiceProducts_Client implements MarketplaceWebServiceProdu
      */
     public function __construct($awsAccessKeyId, $awsSecretAccessKey, $applicationName, $applicationVersion, $config = null)
     {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->_awsAccessKeyId = $awsAccessKeyId;
         $this->_awsSecretAccessKey = $awsSecretAccessKey;


### PR DESCRIPTION
Fixes deprecation warning (`PHP Deprecated:  iconv_set_encoding(): Use of iconv.internal_encoding is deprecated in ...`) on PHP 5.6+