### PR TITLE
Extract echo and print_r logs to use a PSR-3 logger interface.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+vendor

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     ],
 
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "psr/log": "^1.0.1"
     },
 
     "autoload": {
         "psr-0": { "CaponicaAmazonMwsComplete\\": "src/" }
     }
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,67 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "b7bbf2d2173c4fa34e87224c566a876d",
+    "packages": [
+        {
+            "name": "psr/log",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "3490ba5925e6dcbe6de950c5c6b8dce9f6e96eda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/3490ba5925e6dcbe6de950c5c6b8dce9f6e96eda",
+                "reference": "3490ba5925e6dcbe6de950c5c6b8dce9f6e96eda",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2018-04-03T15:59:15+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.2"
+    },
+    "platform-dev": []
+}

--- a/src/CaponicaAmazonMwsComplete/ClientPack/CaponicaClientPack.php
+++ b/src/CaponicaAmazonMwsComplete/ClientPack/CaponicaClientPack.php
@@ -3,6 +3,7 @@
 namespace CaponicaAmazonMwsComplete\ClientPack;
 
 use CaponicaAmazonMwsComplete\Domain\Throttle\ThrottleAwareClientPackInterface;
+use CaponicaAmazonMwsComplete\Service\LoggerService;
 
 class CaponicaClientPack {
     public static function throttledCall(ThrottleAwareClientPackInterface $clientPack, $method, $options, $weight=null) {
@@ -12,7 +13,7 @@ class CaponicaClientPack {
             return $clientPack->$method($options);
         } catch (\Exception $e) {
             if (method_exists($e, 'getErrorCode') && 'RequestThrottled' == $e->getErrorCode()) {
-                echo "\nThe request was throttled";
+                LoggerService::logMessage("The request was throttled", LoggerService::INFO);
                 if ($snoozeLength = $clientPack->getThrottleManager()->getRestoreInterval($method, $weight)) {
                     $clientPack->getThrottleManager()->exhaustRequestQuotaForMethod($method);
                     self::snooze(ceil($snoozeLength) * 2); // Double the normal snooze since we bounced off the server limit
@@ -32,7 +33,7 @@ class CaponicaClientPack {
      */
     private static function snooze($snoozeLength) {
         if ($snoozeLength > 0) {
-            echo "\nSnoozing for $snoozeLength seconds";
+            LoggerService::logMessage("Snoozing for $snoozeLength seconds", LoggerService::DEBUG);
             if (is_int($snoozeLength)) {
                 sleep($snoozeLength);
             } else {

--- a/src/CaponicaAmazonMwsComplete/ClientPool/MwsClientPool.php
+++ b/src/CaponicaAmazonMwsComplete/ClientPool/MwsClientPool.php
@@ -14,6 +14,7 @@ use CaponicaAmazonMwsComplete\ClientPack\MwsFeedAndReportClientPack;
 use CaponicaAmazonMwsComplete\ClientPack\MwsFinanceClientPack;
 use CaponicaAmazonMwsComplete\ClientPack\MwsOrderClientPack;
 use CaponicaAmazonMwsComplete\ClientPack\MwsProductClientPack;
+use Psr\Log\LoggerInterface;
 
 class MwsClientPool {
     // $channelId can be used to stash an id that your code uses to reference this Client Pool's Amazon site
@@ -42,6 +43,19 @@ class MwsClientPool {
 
     /** @var MwsClientPoolConfig */
     protected $config;
+
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /**
+     * MwsClientPool constructor.
+     *
+     * @param LoggerInterface|null $logger
+     */
+    public function __construct(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
 
     public function setConfig($config=[], $siteCode=null) {
         $this->config = new MwsClientPoolConfig($config, $siteCode);
@@ -82,7 +96,7 @@ class MwsClientPool {
      */
     public function getProductClientPack() {
         if(empty($this->productClientPack)) {
-            $this->productClientPack = new MwsProductClientPack($this->config);
+            $this->productClientPack = new MwsProductClientPack($this->config, $this->logger);
         }
         return $this->productClientPack;
     }

--- a/src/CaponicaAmazonMwsComplete/Domain/Throttle/ThrottledRequestLogCollection.php
+++ b/src/CaponicaAmazonMwsComplete/Domain/Throttle/ThrottledRequestLogCollection.php
@@ -2,6 +2,8 @@
 
 namespace CaponicaAmazonMwsComplete\Domain\Throttle;
 
+use CaponicaAmazonMwsComplete\Service\LoggerService;
+
 final class ThrottledRequestLogCollection {
     const RESTORE_BASIS_REQUEST = 'request';
     const RESTORE_BASIS_WEIGHT  = 'weight';
@@ -43,7 +45,7 @@ final class ThrottledRequestLogCollection {
             return;
         }
         for ($i=1; $i<=$slotsToFill; ++$i) {
-            echo "\nAdding fake entry #{$i} to Throttle log to fill a slot";
+            LoggerService::logMessage("Adding fake entry #{$i} to Throttle log to fill a slot", LoggerService::DEBUG);
             $this->addLog($apiMethod);
         }
     }

--- a/src/CaponicaAmazonMwsComplete/Service/LoggerService.php
+++ b/src/CaponicaAmazonMwsComplete/Service/LoggerService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace CaponicaAmazonMwsComplete\Service;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * LoggerService singleton
+ */
+class LoggerService
+{
+
+    const EMERGENCY = LogLevel::EMERGENCY;
+    const ALERT = LogLevel::ALERT;
+    const CRITICAL = LogLevel::CRITICAL;
+    const ERROR = LogLevel::ERROR;
+    const WARNING = LogLevel::WARNING;
+    const NOTICE = LogLevel::NOTICE;
+    const INFO = LogLevel::INFO;
+    const DEBUG = LogLevel::DEBUG;
+
+    /**
+     * @var LoggerInterface|null
+     */
+    private static $logger;
+
+    /**
+     * Log error messages.
+     *
+     * @param $message
+     * @param $level
+     * @param $context
+     */
+    public static function logMessage($message, $level = self::INFO, $context = [])
+    {
+        if (self::$logger) {
+            self::$logger->log($level, $message, $context);
+        }
+    }
+
+    /**
+     * Set the default logger.
+     *
+     * @param LoggerInterface $logger
+     */
+    public static function setDefaultLogger(LoggerInterface $logger)
+    {
+        self::$logger = $logger;
+    }
+
+    /**
+     * Return the default logger.
+     *
+     * @return LoggerInterface|null
+     */
+    public static function getDefaultLogger() {
+        return self::$logger;
+    }
+}


### PR DESCRIPTION
The logger can be passed into the MwsClientPool and MwsProductClientPack constructors.

Classes like CaponicaClientPack and ThrottledRequestLogCollection will use the global LoggerService singleton for logging as the interface can't be easily passed through to them.

This change should be backwards compatible.

Addresses #21 