### PR TITLE
Allow Amazon classes to be loaded via autoloader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     },
 
     "autoload": {
-        "psr-0": { "CaponicaAmazonMwsComplete\\": "src/" }
+        "psr-0": {
+            "CaponicaAmazonMwsComplete\\": "src/",
+            "": "src/AmazonPhpClientLibrary/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,19 @@
     "autoload": {
         "psr-0": {
             "CaponicaAmazonMwsComplete\\": "src/",
-            "": "src/AmazonPhpClientLibrary/"
+            "FBAInboundServiceMWS_": "src/AmazonPhpClientLibrary/",
+            "FBAInventoryServiceMWS_": "src/AmazonPhpClientLibrary/",
+            "FBAOutboundServiceMWS_": "src/AmazonPhpClientLibrary/",
+            "MarketplaceWebService_": "src/AmazonPhpClientLibrary/",
+            "MarketplaceWebServiceOrders_": "src/AmazonPhpClientLibrary/",
+            "MarketplaceWebServiceProducts_": "src/AmazonPhpClientLibrary/",
+            "MarketplaceWebServiceSellers_": "src/AmazonPhpClientLibrary/",
+            "MWSCartService_": "src/AmazonPhpClientLibrary/",
+            "MWSCustomerService_": "src/AmazonPhpClientLibrary/",
+            "MWSFinancesService_": "src/AmazonPhpClientLibrary/",
+            "MWSMerchantFulfillmentService_": "src/AmazonPhpClientLibrary/",
+            "MWSRecommendationsSectionService_": "src/AmazonPhpClientLibrary/",
+            "MWSSubscriptionsService_": "src/AmazonPhpClientLibrary/"
         }
     }
 }


### PR DESCRIPTION
If I try to generate a request like so:

```php
        $serviceStatusRequest = new MWSMerchantFulfillmentService_Model_GetServiceStatusRequest;
```

The autoloader currently cannot find this class. This PR adds the Amazon PHP client to the autoloader.